### PR TITLE
Increase max Connection Size

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -81,6 +81,7 @@ services:
     command:
       - --character-set-server=utf8mb4
       - --collation-server=utf8mb4_unicode_ci
+      - --max_connections=1000
     environment:
       MYSQL_ROOT_PASSWORD: smart
       MYSQL_DATABASE: smart


### PR DESCRIPTION
- Current max connection size is defined to 151
- try to increase max connections to 1000

https://medium.com/@kauminikg/how-to-increase-max-connections-in-mysql-docker-container-772ae17e3526