### PR TITLE
fix(attachment urls): return readable urls

### DIFF
--- a/app/models/data_resources/resource_modules/media_content.rb
+++ b/app/models/data_resources/resource_modules/media_content.rb
@@ -15,7 +15,6 @@ class MediaContent < ApplicationRecord
 
   # if in configs for a resource defined, move an asset to defined external storage
   # and switch urls stored in source_url.
-  #
   def convert_source_url_to_external_storage
     return unless converting_activated_for_current_resource?
 
@@ -27,7 +26,11 @@ class MediaContent < ApplicationRecord
     begin
       uri = URI.open(source_url.url)
       file = File.open(uri)
-      attachment.attach(io: file, filename: File.basename(file))
+      attachment.attach(
+        io: file,
+        filename: File.basename(URI.parse(source_url.url).path) || File.basename(file),
+        content_type: uri.content_type
+      )
     rescue StandardError
       return
     end

--- a/config/initializers/storage_blob_override.rb
+++ b/config/initializers/storage_blob_override.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+Rails.application.config.to_prepare do
+  require "active_storage/blob"
+
+  ActiveStorage::Blob.class_eval do
+    def key
+      self[:key] ||= [self.class.generate_unique_secure_token, filename.to_s].join("-")
+    end
+  end
+end


### PR DESCRIPTION
model:
- extended file name determination base on the `source_url`
- passed `content_type` as well

model + controller:
- created url with `rails_blob_path` that routes through the rails app and redirects to a fileserver url, see https://msp-greg.github.io/rails_gem_5/file.active_storage_overview.html#linking-to-files

credentials:
- added the mainserver url in credentials in order to be used for the attachment url creation

routes:
- added constraint to not run into 404 for paths with /rails/active_storage, like the new urls that will look like: http://localhost:4000/rails/active_storage/blobs/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBWZz09IiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--40868bae79837b0d276e11960f70d3a16d527c55/header_panda_baumstamm_mitte.jpg

SVA-738

<img width="466" alt="image" src="https://user-images.githubusercontent.com/1942953/236529736-29197544-18d7-42bc-bc08-19df51d2812c.png">