### PR TITLE
Erhöhung der Access Token Ablaufzeit

### DIFF
--- a/config/initializers/doorkeeper.rb
+++ b/config/initializers/doorkeeper.rb
@@ -46,7 +46,7 @@ Doorkeeper.configure do
   # Access token expiration time (default 2 hours).
   # If you want to disable expiration, set this to nil.
   #
-  # access_token_expires_in 2.hours
+  access_token_expires_in 24.hours
 
   # Assign custom TTL for access tokens. Will be used instead of access_token_expires_in
   # option if defined. In case the block returns `nil` value Doorkeeper fallbacks to


### PR DESCRIPTION
Die Konfiguration der Access Token Ablaufzeit wurde von 2 auf 24 Stunden erhöht. Dies ermöglicht eine längere Verwendung des Access Tokens, sodass lang laufende Imports möglich sind.