### PR TITLE
Update auf neueste Patchversion von 5.7

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -77,7 +77,7 @@ services:
         condition: on-failure
 
   db:
-    image: mysql:5.7.21
+    image: mysql:5.7-debian
     command:
       - --character-set-server=utf8mb4
       - --collation-server=utf8mb4_unicode_ci


### PR DESCRIPTION
Die Version mysql:5.7.21 gibt es nicht mehr und verursacht somit bei builds Probleme. Wir aktualisieren hiermit auf die lates 5.7. Version die derzeit mysql:5.7.42 ist

Danach sollten auch die automatisierten Backups wieder laufen.