### PR TITLE
Setting German as default language with English as fallback

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -42,5 +42,7 @@ module SmartVillageAppMainserver
     config.generators.system_tests = nil
 
     config.i18n.available_locales = %i[de en]
+    config.i18n.default_locale = :de
+    config.i18n.fallbacks = [:en]
   end
 end


### PR DESCRIPTION
Implementation of German as the standard translation language, with a robust fallback mechanism to English in case the German translation is missing, for efficient handling of I18n::MissingTranslation errors

SVA-285