### PR TITLE
fix: first_or_create to find_or_create_by

### DIFF
--- a/spec/mailers/previews/defect_report_mailer_preview.rb
+++ b/spec/mailers/previews/defect_report_mailer_preview.rb
@@ -11,11 +11,9 @@ class DefectReportMailerPreview < ActionMailer::Preview
     generic_item.content_blocks = [OpenStruct.new(body: "Test mit mehr Worten", title: "Test")]
     generic_item.external_reference = OpenStruct.new(unique_id: "1234567890")
 
-    StaticContent.first_or_create(
-      name: "defectreport-notify-for-category",
-      data_type: "json",
-      content: "{\"app_name\":\"Test-App\",\"mail_footer\":[\"Zeile 1\", \"\", \"Zeile 2\"]}"
-    )
+    StaticContent.find_or_create_by(name: "defectreport-notify-for-category", data_type: "json" ) do |s|
+       s.content = "{\"app_name\":\"Test-App\",\"mail_footer\":[\"Zeile 1\", \"\", \"Zeile 2\"]}" 
+    end
 
     DefectReportMailer.notify_for_category(generic_item)
   end
@@ -33,11 +31,9 @@ class DefectReportMailerPreview < ActionMailer::Preview
     generic_item.addresses = [OpenStruct.new(street: "Straße", zip: "03443", city: "Stadt", geo_location: OpenStruct.new(latitude: 50.1212, longitude: 13.3434))]
     generic_item.external_reference = OpenStruct.new(unique_id: "1234567890")
 
-    StaticContent.first_or_create(
-      name: "defectreport-notify-for-category",
-      data_type: "json",
-      content: "{\"app_name\":\"Test-App\",\"mail_footer\":[\"Zeile 1\", \"\", \"Zeile 2\"]}"
-    )
+    StaticContent.find_or_create_by(name: "defectreport-notify-for-category", data_type: "json") do |s|
+        s.content = "{\"app_name\":\"Test-App\",\"mail_footer\":[\"Zeile 1\", \"\", \"Zeile 2\"]}"
+    end
 
     DefectReportMailer.notify_for_category(generic_item)
   end

--- a/spec/mailers/previews/noticeboard_mailer_preview.rb
+++ b/spec/mailers/previews/noticeboard_mailer_preview.rb
@@ -14,11 +14,9 @@ class NoticeboardMailerPreview < ActionMailer::Preview
     generic_item.content_blocks = [OpenStruct.new(body: "Test", title: "Test")]
     generic_item.external_reference = OpenStruct.new(unique_id: "1234567890")
 
-    StaticContent.first_or_create(
-      name: "noticeboard-notify-creator",
-      data_type: "json",
-      content: "{\"app_name\":\"Test-App\",\"mail_footer\":[\"Zeile 1\", \"\", \"Zeile 2\"]}"
-    )
+    StaticContent.find_or_create_by(name: "noticeboard-notify-creator", data_type: "json") do |s|
+      s.content = "{\"app_name\":\"Test-App\",\"mail_footer\":[\"Zeile 1\", \"\", \"Zeile 2\"]}"
+    end
 
     NoticeboardMailer.notify_creator(generic_item)
   end
@@ -45,11 +43,9 @@ class NoticeboardMailerPreview < ActionMailer::Preview
       terms_of_service: true
     )
 
-    StaticContent.first_or_create(
-      name: "noticeboard_notify_creator",
-      data_type: "json",
-      content: "{\"app_name\":\"Test-App\",\"mail_footer\":[\"Zeile 1\", \"\", \"Zeile 2\"]}"
-    )
+    StaticContent.find_or_create_by(name: "noticeboard-notify-creator", data_type: "json") do |s|
+      s.content = "{\"app_name\":\"Test-App\",\"mail_footer\":[\"Zeile 1\", \"\", \"Zeile 2\"]}"
+    end
 
     NoticeboardMailer.new_message_for_entry(generic_item_message)
   end


### PR DESCRIPTION
The first_or_create method merely checks if a StaticContent object exists or not. On the other hand, find_or_create_by will check if an object exists with specific arguments, and if it doesn't, it will create one using these arguments as well.