### PR TITLE
feat(event): recurring dates

### DIFF
--- a/app/graphql/mutations/create_event_record.rb
+++ b/app/graphql/mutations/create_event_record.rb
@@ -60,6 +60,10 @@ module Mutations
                         accessibility_information.to_h
                       }
     argument :tags, [String], as: :tag_list, required: false
+    argument :recurring, String, required: false
+    argument :recurring_weekdays, [String], required: false
+    argument :recurring_type, String, required: false
+    argument :recurring_interval, String, required: false
 
     field :event, Types::QueryTypes::EventRecordType, null: true
 

--- a/app/graphql/types/query_types/event_record_type.rb
+++ b/app/graphql/types/query_types/event_record_type.rb
@@ -27,6 +27,10 @@ module Types
     field :price_informations, [QueryTypes::PriceType], null: true
     field :accessibility_information, QueryTypes::AccessibilityInformationType, null: true
     field :tag_list, [String], null: true
+    field :recurring, Boolean, null: true
+    field :recurring_weekdays, [Integer], null: true
+    field :recurring_type, Integer, null: true
+    field :recurring_interval, Integer, null: true
     field :updated_at, String, null: true
     field :created_at, String, null: true
   end

--- a/app/models/data_resources/event_record.rb
+++ b/app/models/data_resources/event_record.rb
@@ -32,6 +32,8 @@ class EventRecord < ApplicationRecord
   has_many :dates, as: :dateable, class_name: "FixedDate", dependent: :destroy
   has_one :external_reference, as: :external, dependent: :destroy
 
+  serialize :recurring_weekdays, Array
+
   # defined by FilterByRole
   # scope :visible, -> { where(visible: true) }
 
@@ -233,15 +235,19 @@ end
 #
 # Table name: event_records
 #
-#  id               :bigint           not null, primary key
-#  parent_id        :integer
-#  region_id        :bigint
-#  description      :text(65535)
-#  repeat           :boolean
-#  title            :string(255)
-#  created_at       :datetime         not null
-#  updated_at       :datetime         not null
-#  data_provider_id :integer
-#  external_id      :string(255)
-#  visible          :boolean          default(TRUE)
+#  id                 :bigint           not null, primary key
+#  parent_id          :integer
+#  region_id          :bigint
+#  description        :text(65535)
+#  repeat             :boolean
+#  title              :string(255)
+#  created_at         :datetime         not null
+#  updated_at         :datetime         not null
+#  data_provider_id   :integer
+#  external_id        :string(255)
+#  visible            :boolean          default(TRUE)
+#  recurring          :boolean          default(FALSE)
+#  recurring_weekdays :string(255)
+#  recurring_type     :integer
+#  recurring_interval :integer
 #

--- a/app/services/recurring_dates_for_event_service.rb
+++ b/app/services/recurring_dates_for_event_service.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+class RecurringDatesForEventService
+  def initialize(event)
+    @event_id = event.id
+    @date_start = event.dates.first.date_start
+    @date_end = event.dates.first.date_end
+    @time_start = event.dates.first.time_start
+    @time_end = event.dates.first.time_end
+    @weekdays = event.recurring_weekdays
+    @type = event.recurring_type # 0 - daily, 1 - weekly, 2 - monthly, 3 - yearly
+    @interval = event.recurring_interval
+  end
+
+  def create_with_pattern
+    case @type
+    when 0
+      create_daily_events
+    when 1
+      # TODO: create_weekly_events
+    when 2
+      # TODO: create_monthly_events
+    when 3
+      # TODO: create_yearly_events
+    end
+  end
+
+  private
+
+    # create a date for all appointments between date_start and date_end based on the days interval
+    def create_daily_events
+      while @date_start <= @date_end
+        create_date(
+          date_start: @date_start,
+          date_end: @date_start,
+          time_start: @time_start,
+          time_end: @time_end
+        )
+
+        @date_start += @interval.days
+      end
+    end
+
+    def create_date(params)
+      FixedDate.create(
+        params.merge(
+          dateable_type: "EventRecord",
+          dateable_id: @event_id
+        )
+      )
+    end
+end

--- a/app/services/recurring_dates_for_event_service.rb
+++ b/app/services/recurring_dates_for_event_service.rb
@@ -22,7 +22,7 @@ class RecurringDatesForEventService
     when 2
       create_monthly_events
     when 3
-      # TODO: create_yearly_events
+      create_yearly_events
     end
   end
 
@@ -60,6 +60,15 @@ class RecurringDatesForEventService
       while @date_start <= @date_end
         create_date
         @date_start += @interval.months
+      end
+    end
+
+    # create a date for all appointments between `date_start` and `date_end` based on the years
+    # interval
+    def create_yearly_events
+      while @date_start <= @date_end
+        create_date
+        @date_start += @interval.years
       end
     end
 

--- a/app/services/recurring_dates_for_event_service.rb
+++ b/app/services/recurring_dates_for_event_service.rb
@@ -20,7 +20,7 @@ class RecurringDatesForEventService
     when 1
       create_weekly_events
     when 2
-      # TODO: create_monthly_events
+      create_monthly_events
     when 3
       # TODO: create_yearly_events
     end
@@ -28,7 +28,8 @@ class RecurringDatesForEventService
 
   private
 
-    # create a date for all appointments between date_start and date_end based on the days interval
+    # create a date for all appointments between `date_start` and `date_end` based on the days
+    # interval
     def create_daily_events
       while @date_start <= @date_end
         create_date
@@ -36,8 +37,8 @@ class RecurringDatesForEventService
       end
     end
 
-    # create a date for all appointments between date_start and date_end based on the weeks interval
-    # considering the weekdays in each week.
+    # create a date for all appointments between `date_start` and `date_end` based on the weeks
+    # interval considering the weekdays in each week
     def create_weekly_events
       beginning_of_week = @date_start.beginning_of_week
 
@@ -50,6 +51,15 @@ class RecurringDatesForEventService
         end
 
         beginning_of_week += @interval.weeks
+      end
+    end
+
+    # create a date for all appointments between `date_start` and `date_end` based on the months
+    # interval
+    def create_monthly_events
+      while @date_start <= @date_end
+        create_date
+        @date_start += @interval.months
       end
     end
 

--- a/app/services/recurring_dates_for_event_service.rb
+++ b/app/services/recurring_dates_for_event_service.rb
@@ -45,6 +45,7 @@ class RecurringDatesForEventService
       while beginning_of_week <= @date_end
         @weekdays.each do |weekday|
           next unless (beginning_of_week + weekday.days) >= @date_start
+          next unless (beginning_of_week + weekday.days) <= @date_end
 
           @date_start = beginning_of_week + weekday.days
           create_date

--- a/db/migrate/20230803145654_add_recurrings_to_event_records.rb
+++ b/db/migrate/20230803145654_add_recurrings_to_event_records.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class AddRecurringsToEventRecords < ActiveRecord::Migration[5.2]
+  def change
+    add_column :event_records, :recurring, :boolean, default: false
+    add_column :event_records, :recurring_weekdays, :string
+    add_column :event_records, :recurring_type, :integer
+    add_column :event_records, :recurring_interval, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_01_20_141513) do
+ActiveRecord::Schema.define(version: 2023_08_03_145654) do
 
   create_table "accessibility_informations", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci", force: :cascade do |t|
     t.text "description"
@@ -234,6 +234,10 @@ ActiveRecord::Schema.define(version: 2023_01_20_141513) do
     t.integer "data_provider_id"
     t.string "external_id"
     t.boolean "visible", default: true
+    t.boolean "recurring", default: false
+    t.string "recurring_weekdays"
+    t.integer "recurring_type"
+    t.integer "recurring_interval"
     t.index ["data_provider_id"], name: "index_event_records_on_data_provider_id"
     t.index ["region_id"], name: "index_event_records_on_region_id"
   end

--- a/spec/factories/event_records.rb
+++ b/spec/factories/event_records.rb
@@ -23,15 +23,19 @@ end
 #
 # Table name: event_records
 #
-#  id               :bigint           not null, primary key
-#  parent_id        :integer
-#  region_id        :bigint
-#  description      :text(65535)
-#  repeat           :boolean
-#  title            :string(255)
-#  created_at       :datetime         not null
-#  updated_at       :datetime         not null
-#  data_provider_id :integer
-#  external_id      :string(255)
-#  visible          :boolean          default(TRUE)
+#  id                 :bigint           not null, primary key
+#  parent_id          :integer
+#  region_id          :bigint
+#  description        :text(65535)
+#  repeat             :boolean
+#  title              :string(255)
+#  created_at         :datetime         not null
+#  updated_at         :datetime         not null
+#  data_provider_id   :integer
+#  external_id        :string(255)
+#  visible            :boolean          default(TRUE)
+#  recurring          :boolean          default(FALSE)
+#  recurring_weekdays :string(255)
+#  recurring_type     :integer
+#  recurring_interval :integer
 #

--- a/spec/models/event_record_spec.rb
+++ b/spec/models/event_record_spec.rb
@@ -121,15 +121,19 @@ end
 #
 # Table name: event_records
 #
-#  id               :bigint           not null, primary key
-#  parent_id        :integer
-#  region_id        :bigint
-#  description      :text(65535)
-#  repeat           :boolean
-#  title            :string(255)
-#  created_at       :datetime         not null
-#  updated_at       :datetime         not null
-#  data_provider_id :integer
-#  external_id      :string(255)
-#  visible          :boolean          default(TRUE)
+#  id                 :bigint           not null, primary key
+#  parent_id          :integer
+#  region_id          :bigint
+#  description        :text(65535)
+#  repeat             :boolean
+#  title              :string(255)
+#  created_at         :datetime         not null
+#  updated_at         :datetime         not null
+#  data_provider_id   :integer
+#  external_id        :string(255)
+#  visible            :boolean          default(TRUE)
+#  recurring          :boolean          default(FALSE)
+#  recurring_weekdays :string(255)
+#  recurring_type     :integer
+#  recurring_interval :integer
 #


### PR DESCRIPTION
This PR introduces new event fields for describing a recurring pattern. Based on this pattern we can create `fixed_date`s for events dynamically. There is a new service that gets called, if recurring dates should be stored in the data base.

The pattern is based on three fields: `recurring_weekdays`, `recurring_type` and `recurring_interval`.
The weekdays are selectable for weekly repetitions and are described with numbers from 0 to 6 for Monday to Sunday.
The type describes the daily, weekly, monthly or yearly repetition based on a number from 0 to 3.
The interval indicates how often the repetition should occur (every two days? every four weeks? every year?).

#### Example combinations

Christmas every year from 24th December 2023 to 24th December 2073:
- `recurring_weekdays` = nil
- `recurring_type` = 3
- `recurring_interval` = 1

Weekdays from 1st August 2023 to 31st August 2023:
- `recurring_weekdays` = [0,1,2,3,4]
- `recurring_type` = 1
- `recurring_interval` = 1

#### Screenshot of dates stored in the database for the second example

<img width="322" alt="image" src="https://github.com/smart-village-solutions/smart-village-app-mainserver/assets/1942953/b43d4e0d-8f16-4640-9d17-758a6d143da6">

SVA-1009