### PR TITLE
fix(scope): make scope upcoming chainable

### DIFF
--- a/app/models/data_resources/event_record.rb
+++ b/app/models/data_resources/event_record.rb
@@ -77,9 +77,9 @@ class EventRecord < ApplicationRecord
 
   scope :upcoming, lambda { |current_user = nil|
     event_records = if current_user.present?
-                      EventRecord.filtered_for_current_user(current_user)
+                      filtered_for_current_user(current_user)
                     else
-                      EventRecord.all
+                      all
                     end
 
     event_records


### PR DESCRIPTION
der Scope Upcomming könnte bisher nicht mit einem anderen Scope verknüpft werden, weil er neu suchte (wie ein :unscoped) und ein neues ActiveRecord::Relation-Objekt zurückgegeben hat.

Durch die Anpassung wird der Scope mit anderen verkettbar und der Filter der bereits existiert wird weiterhin berücksichtigt. bsp.: Category.first.event_records.upcoming

SVA-1154