### PR TITLE
fix: Compare to EventRecords with address data

### DIFF
--- a/app/models/data_resources/event_record.rb
+++ b/app/models/data_resources/event_record.rb
@@ -128,7 +128,7 @@ class EventRecord < ApplicationRecord
   end
 
   def compareable_attributes
-    except_attributes = ["id", "created_at", "updated_at", "tag_list", "category_id", "region_id", "dateable_id"]
+    except_attributes = ["id", "created_at", "updated_at", "tag_list", "category_id", "region_id", "dateable_id", "addressable_id"]
 
     list_of_attributes = {}
     list_of_attributes.merge!(attributes.except(*except_attributes))


### PR DESCRIPTION
An external/new EventRecord coming by an Importer does not have an addressable_id to compare.
With this fix, "less" duplicates schould be imported from now on.

SVA-1153