### PR TITLE
fix: scope check for current_user

### DIFF
--- a/app/graphql/types/query_type.rb
+++ b/app/graphql/types/query_type.rb
@@ -114,8 +114,10 @@ module Types
     def event_records_addresses
       upcoming_event_ids = EventRecord.upcoming(context[:current_user]).pluck(:id)
 
-      Address.joins("INNER JOIN event_records ON event_records.id = addresses.addressable_id AND addresses.addressable_type = 'EventRecord'")
-        .where(event_records: { id: upcoming_event_ids })
+      Address.joins("
+        INNER JOIN event_records ON event_records.id = addresses.addressable_id
+        AND addresses.addressable_type = 'EventRecord'
+      ").where(event_records: { id: upcoming_event_ids })
     end
 
     def news_item(id:)

--- a/app/graphql/types/query_type.rb
+++ b/app/graphql/types/query_type.rb
@@ -114,12 +114,8 @@ module Types
     def event_records_addresses
       upcoming_event_ids = EventRecord.upcoming.pluck(:id)
 
-      Address.find_by_sql("
-        SELECT `#{Address.table_name}`.*
-        FROM `#{Address.table_name}`
-        INNER JOIN `#{EventRecord.table_name}` ON `#{EventRecord.table_name}`.`id` = `#{Address.table_name}`.`addressable_id` AND `#{Address.table_name}`.`addressable_type` = '#{EventRecord.name}'
-        WHERE `#{EventRecord.table_name}`.`id` IN (#{upcoming_event_ids.join(",")})
-      ")
+      Address.joins("INNER JOIN event_records ON event_records.id = addresses.addressable_id AND addresses.addressable_type = 'EventRecord'")
+        .where(event_records: { id: upcoming_event_ids })
     end
 
     def news_item(id:)

--- a/app/graphql/types/query_type.rb
+++ b/app/graphql/types/query_type.rb
@@ -112,7 +112,7 @@ module Types
     end
 
     def event_records_addresses
-      upcoming_event_ids = EventRecord.upcoming.pluck(:id)
+      upcoming_event_ids = EventRecord.upcoming(context[:current_user]).pluck(:id)
 
       Address.joins("INNER JOIN event_records ON event_records.id = addresses.addressable_id AND addresses.addressable_type = 'EventRecord'")
         .where(event_records: { id: upcoming_event_ids })

--- a/app/services/resource_service.rb
+++ b/app/services/resource_service.rb
@@ -142,6 +142,7 @@ class ResourceService
 
     def unchanged_attributes?
       return false if @old_resource.blank?
+
       if @old_resource.respond_to?(:compareable_attributes)
         return @resource.compareable_attributes == @old_resource.compareable_attributes
       end


### PR DESCRIPTION
:upcoming ist in event_records folgendermaßen definiert:

```
scope :upcoming, lambda { |current_user = nil|
    event_records = if current_user.present?
                      filtered_for_current_user(current_user)
                    else
                      all
                    end
...
```

d.h.: Wenn es keinen `current_user` gibt, dann wir immer `:all` zurückgeliefert. Das führt dazu, dass die Scopes `:filtered_for_current_user` und bei SaaS zusätzlich `:by_data_provider` nicht ausgeführt werden und es somit keine Filterung auf die DataProvider und damit bei SaaS auch nicht auf die Municipality erfolgen würde.

SVA-1174