### PR TITLE
feat(push notifications): exclude MoWaS regional keys

### DIFF
--- a/app/controllers/notification/devices_controller.rb
+++ b/app/controllers/notification/devices_controller.rb
@@ -129,7 +129,7 @@ class Notification::DevicesController < ApplicationController
     # Never trust parameters from the scary internet, only allow the white list through.
     def notification_device_params
       params.require(:notification_device).permit(
-        :token, :device_type, exclude_data_provider_ids: []
+        :token, :device_type, exclude_data_provider_ids: [], exclude_mowas_regional_keys: []
       )
     end
 end

--- a/app/graphql/mutations/send_push_notification.rb
+++ b/app/graphql/mutations/send_push_notification.rb
@@ -9,13 +9,22 @@ module Mutations
 
     type Types::StatusType
 
-    def resolve(title:, body: nil, data: { data_provider_id: nil }, force_create: nil)
+    def resolve(title:, body: nil, data: { data_provider_id: nil, payload: nil }, force_create: nil)
       raise "Access not permitted" unless roles[:role_push_notification] == true
 
       message_options = { title: title }
       message_options[:body] = body if body.present?
-      if data.data_provider_id.present?
-        message_options[:data] = { data_provider_id: data.data_provider_id.to_i }
+
+      if data.present?
+        message_options[:data] = {}
+
+        if data.data_provider_id.present?
+          message_options[:data][:data_provider_id] = data.data_provider_id.to_i
+        end
+
+        if data.mowas_regional_keys.present?
+          message_options[:data][:mowas_regional_keys] = data.mowas_regional_keys
+        end
       end
 
       PushNotification.delay.send_notifications(message_options) if title.present?

--- a/app/graphql/resolvers/news_items_search.rb
+++ b/app/graphql/resolvers/news_items_search.rb
@@ -28,6 +28,7 @@ class Resolvers::NewsItemsSearch
   option :dataProvider, type: types.String, with: :apply_data_provider
   option :dataProviderId, type: types.ID, with: :apply_data_provider_id
   option :excludeDataProviderIds, type: types[types.ID], with: :apply_exclude_data_provider_ids
+  option :excludeMowasRegionalKeys, type: types.String, with: :apply_exclude_mowas_regional_keys
   option :categoryId, type: types.ID, with: :apply_category_id
   option :categoryIds, type: types[types.ID], with: :apply_category_ids
 
@@ -57,6 +58,18 @@ class Resolvers::NewsItemsSearch
 
   def apply_exclude_data_provider_ids(scope, value)
     scope.where.not(data_provider_id: value)
+  end
+
+  def apply_exclude_mowas_regional_keys(scope, value)
+    scope = scope.where(payload: nil).or(scope.where.not("payload LIKE ?", "%regionalKeys%"))
+
+    value.split(",").map(&:strip).each do |regional_key|
+      next if regional_key.blank?
+
+      scope = scope.or(scope.where.not("payload LIKE ?", "%#{regional_key}%"))
+    end
+
+    scope
   end
 
   def apply_category_id(scope, value)

--- a/app/graphql/types/input_types/push_notification_data_input.rb
+++ b/app/graphql/types/input_types/push_notification_data_input.rb
@@ -5,5 +5,6 @@ module Types
     argument :id, ID, required: false
     argument :query_type, String, required: false
     argument :data_provider_id, ID, required: false
+    argument :mowas_regional_keys, [AnyPrimitiveType], required: false
   end
 end

--- a/app/jobs/send_single_push_notification_job.rb
+++ b/app/jobs/send_single_push_notification_job.rb
@@ -3,17 +3,17 @@
 class SendSinglePushNotificationJob < ApplicationJob
   queue_as :default
 
+  # device_token = "ExponentPushToken[RkCuwM123456778g29lQb0ZK]"
   # message_options = {
   #   title: push_title,
   #   body: push_body,
   #   data: {
   #     id: id,
-  #     query_type: self.class.to_s
+  #     query_type: self.class.to_s,
+  #     data_provider_id: data_provider.id,
+  #     payload: payload
   #   }
   # }
-  #
-  # device_token = "ExponentPushToken[RkCuwM123456778g29lQb0ZK]"
-
   def send_single_push_notification(device_token, message_options)
     client = Exponent::Push::Client.new
     messages = [message_options.merge(to: device_token)]

--- a/app/models/notification/device.rb
+++ b/app/models/notification/device.rb
@@ -16,6 +16,7 @@ class Notification::Device < ApplicationRecord
            source: :notification_push
 
   serialize :exclude_data_provider_ids, Array
+  serialize :exclude_mowas_regional_keys, Array
 
   include Sortable
   sortable_on :device_type, :token
@@ -32,10 +33,11 @@ end
 #
 # Table name: notification_devices
 #
-#  id                        :bigint           not null, primary key
-#  token                     :string(255)
-#  device_type               :integer          default("undefined")
-#  created_at                :datetime         not null
-#  updated_at                :datetime         not null
-#  exclude_data_provider_ids :text(65535)
+#  id                          :bigint           not null, primary key
+#  token                       :string(255)
+#  device_type                 :integer          default("undefined")
+#  created_at                  :datetime         not null
+#  updated_at                  :datetime         not null
+#  exclude_data_provider_ids   :text(65535)
+#  exclude_mowas_regional_keys :text(65535)
 #

--- a/app/services/push_notification.rb
+++ b/app/services/push_notification.rb
@@ -6,7 +6,8 @@
 #   data: {
 #     id: id,
 #     query_type: self.class.to_s,
-#     data_provider_id: data_provider.id
+#     data_provider_id: data_provider.id,
+#     payload: payload
 #   }
 # }
 class PushNotification
@@ -17,13 +18,26 @@ class PushNotification
   end
 
   def self.send_notifications(message_options = {})
+    data = message_options[:data]
+
+    if data.present?
+      data_provider_id = data.fetch(:data_provider_id)
+      mowas_regional_keys = data.fetch(:mowas_regional_keys, [])
+    end
+
     notification_devices = Notification::Device.all
-    data_provider_id = message_options[:data_provider_id]
 
     if data_provider_id.present?
-      notification_devices = Notification::Device.where(
+      notification_devices = notification_devices.where(
         "exclude_data_provider_ids IS NULL OR exclude_data_provider_ids NOT LIKE '%- ?\n%'",
         data_provider_id
+      )
+    end
+
+    if mowas_regional_keys.present?
+      notification_devices = notification_devices.where(
+        "NOT (#{mowas_regional_keys.map { "exclude_mowas_regional_keys LIKE '%- ?\n%'" }.join(' AND ')}) OR exclude_mowas_regional_keys IS NULL",
+        *mowas_regional_keys
       )
     end
 

--- a/app/views/notification/devices/_notification_device.json.jbuilder
+++ b/app/views/notification/devices/_notification_device.json.jbuilder
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
 
-json.extract! notification_device, :id, :token, :device_type, :created_at, :updated_at, :exclude_data_provider_ids
+json.extract! notification_device, :id, :token, :device_type, :created_at, :updated_at,
+                                   :exclude_data_provider_ids, :exclude_mowas_regional_keys
 json.url notification_device_url(notification_device, format: :json)

--- a/db/migrate/20231018112623_add_exclude_mowas_regional_keys_to_notification_devices.rb
+++ b/db/migrate/20231018112623_add_exclude_mowas_regional_keys_to_notification_devices.rb
@@ -1,0 +1,5 @@
+class AddExcludeMowasRegionalKeysToNotificationDevices < ActiveRecord::Migration[5.2]
+  def change
+    add_column :notification_devices, :exclude_mowas_regional_keys, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -384,6 +384,7 @@ ActiveRecord::Schema.define(version: 2023_11_15_101929) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.text "exclude_data_provider_ids"
+    t.text "exclude_mowas_regional_keys"
     t.index ["token"], name: "index_notification_devices_on_token", unique: true
   end
 

--- a/spec/factories/notification_devices.rb
+++ b/spec/factories/notification_devices.rb
@@ -6,6 +6,7 @@ FactoryBot.define do
     token { "RandomToken" }
     device_type { 0 }
     exclude_data_provider_ids { nil }
+    exclude_mowas_regional_keys { nil }
   end
 end
 
@@ -13,10 +14,11 @@ end
 #
 # Table name: notification_devices
 #
-#  id                        :bigint           not null, primary key
-#  token                     :string(255)
-#  device_type               :integer          default("undefined")
-#  created_at                :datetime         not null
-#  updated_at                :datetime         not null
-#  exclude_data_provider_ids :text(65535)
+#  id                          :bigint           not null, primary key
+#  token                       :string(255)
+#  device_type                 :integer          default("undefined")
+#  created_at                  :datetime         not null
+#  updated_at                  :datetime         not null
+#  exclude_data_provider_ids   :text(65535)
+#  exclude_mowas_regional_keys :text(65535)
 #

--- a/spec/models/notification/device_spec.rb
+++ b/spec/models/notification/device_spec.rb
@@ -11,10 +11,11 @@ end
 #
 # Table name: notification_devices
 #
-#  id                        :bigint           not null, primary key
-#  token                     :string(255)
-#  device_type               :integer          default("undefined")
-#  created_at                :datetime         not null
-#  updated_at                :datetime         not null
-#  exclude_data_provider_ids :text(65535)
+#  id                          :bigint           not null, primary key
+#  token                       :string(255)
+#  device_type                 :integer          default("undefined")
+#  created_at                  :datetime         not null
+#  updated_at                  :datetime         not null
+#  exclude_data_provider_ids   :text(65535)
+#  exclude_mowas_regional_keys :text(65535)
 #


### PR DESCRIPTION
- added `exclude_mowas_regional_keys` for push notification devices like `exclude_data_provider_ids` with serializing as array to save regional keys where devices do not want to get push notifications for
- added passing the `payload` of news items to the push notification options data object in order to process contained regional keys
- adjusted logics to check for data in push notification options and building of database query to exclude notification devices
- added possibility to pass regional keys per payload in push notification GraphQL mutation

|mobile-app interface|database example with two regional keys|GraphQL example for sending push|resulting database query|
|---|---|---|---|
|<img width="386" alt="image" src="https://github.com/smart-village-solutions/smart-village-app-mainserver/assets/1942953/444c5fba-3a43-4238-b9f9-9d1daa1baa82">|<img width="261" alt="image" src="https://github.com/smart-village-solutions/smart-village-app-mainserver/assets/1942953/bd6a59c5-9068-4f52-b6b1-1d747a92c858">|<img width="179" alt="image" src="https://github.com/smart-village-solutions/smart-village-app-mainserver/assets/1942953/266be890-35f9-4a8b-aa4e-f75c6e61e75f">|<img width="724" alt="image" src="https://github.com/smart-village-solutions/smart-village-app-mainserver/assets/1942953/a848c9a9-314f-4ee8-8673-9aa5f982530b">|

with these changes, the notification device with excludes for certain MoWaS regional keys will be excludes on sending push notifications.

SVAK-7