### PR TITLE
fix(migration): this migration is no longer needed

### DIFF
--- a/db/migrate/20190821082807_add_defaults_for_data_provider_roles.rb
+++ b/db/migrate/20190821082807_add_defaults_for_data_provider_roles.rb
@@ -1,11 +1,12 @@
 class AddDefaultsForDataProviderRoles < ActiveRecord::Migration[5.2]
   def change
-    DataProvider.all.each do |data_provider|
-      data_provider.role_point_of_interest = true
-      data_provider.role_tour = true
-      data_provider.role_news_item = true
-      data_provider.role_event_record = true
-      data_provider.save
-    end
+    # This migration is no longer needed.
+    # DataProvider.all.each do |data_provider|
+    #   data_provider.role_point_of_interest = true
+    #   data_provider.role_tour = true
+    #   data_provider.role_news_item = true
+    #   data_provider.role_event_record = true
+    #   data_provider.save
+    # end
   end
 end


### PR DESCRIPTION
error in database Migration: Unknown Column in 'Where Clause'

while running a rake task, the process was aborted due to a StandardError. This error occurred during the execution of database migrations, leading to the cancellation of all subsequent migrations.

SVA-1251