### PR TITLE
feat(news items): exclude MoWaS regional keys

### DIFF
--- a/app/graphql/resolvers/news_items_search.rb
+++ b/app/graphql/resolvers/news_items_search.rb
@@ -28,6 +28,7 @@ class Resolvers::NewsItemsSearch
   option :dataProvider, type: types.String, with: :apply_data_provider
   option :dataProviderId, type: types.ID, with: :apply_data_provider_id
   option :excludeDataProviderIds, type: types[types.ID], with: :apply_exclude_data_provider_ids
+  option :excludeMowasRegionalKeys, type: types.String, with: :apply_exclude_mowas_regional_keys
   option :categoryId, type: types.ID, with: :apply_category_id
   option :categoryIds, type: types[types.ID], with: :apply_category_ids
 
@@ -57,6 +58,18 @@ class Resolvers::NewsItemsSearch
 
   def apply_exclude_data_provider_ids(scope, value)
     scope.where.not(data_provider_id: value)
+  end
+
+  def apply_exclude_mowas_regional_keys(scope, value)
+    scope = scope.where(payload: nil).or(scope.where.not("payload LIKE ?", "%regionalKeys%"))
+
+    value.split(",").map(&:strip).each do |regional_key|
+      next if regional_key.blank?
+
+      scope = scope.or(scope.where.not("payload LIKE ?", "%#{regional_key}%"))
+    end
+
+    scope
   end
 
   def apply_category_id(scope, value)


### PR DESCRIPTION
- added `exclude_mowas_regional_keys` filter for news items searches in GraphQL to be able to return data without certain MoWaS regional keys

SVAK-37