### PR TITLE
feat(events): return event records for each date

### DIFF
--- a/app/graphql/resolvers/event_records_search.rb
+++ b/app/graphql/resolvers/event_records_search.rb
@@ -11,15 +11,15 @@ class Resolvers::EventRecordsSearch
 
     begin
       lookahead = context[:extras][:lookahead].selection(:event_records)
+      event_records = event_records.upcoming_with_date_select if lookahead.selects?(:date)
       event_records = event_records.includes(:addresses) if lookahead.selects?(:addresses)
       event_records = event_records.includes(:categories) if lookahead.selects?(:categories)
-      event_records = event_records.includes(:dates) if lookahead.selects?(:list_date) || lookahead.selects?(:dates)
       event_records = event_records.includes(:data_provider) if lookahead.selects?(:data_provider)
     rescue
       # ignore
     end
 
-    event_records.distinct
+    event_records
   }
 
   type types[Types::QueryTypes::EventRecordType]

--- a/app/graphql/resolvers/event_records_search.rb
+++ b/app/graphql/resolvers/event_records_search.rb
@@ -19,7 +19,13 @@ class Resolvers::EventRecordsSearch
       # ignore
     end
 
-    event_records
+    # if the date is requested we need to return all records, because there will be different events
+    # with the same id that only differ in date
+    if lookahead.selects?(:date)
+      event_records
+    else
+      event_records.distinct
+    end
   }
 
   type types[Types::QueryTypes::EventRecordType]

--- a/app/graphql/types/query_types/event_record_type.rb
+++ b/app/graphql/types/query_types/event_record_type.rb
@@ -36,7 +36,7 @@ module Types
     field :created_at, String, null: true
 
     def dates
-      object.dates_upcoming
+      object.dates_upcoming(object.recurring?)
     end
   end
 end

--- a/app/graphql/types/query_types/event_record_type.rb
+++ b/app/graphql/types/query_types/event_record_type.rb
@@ -36,7 +36,7 @@ module Types
     field :created_at, String, null: true
 
     def dates
-      object.upcoming_dates
+      object.dates_upcoming
     end
   end
 end

--- a/app/graphql/types/query_types/event_record_type.rb
+++ b/app/graphql/types/query_types/event_record_type.rb
@@ -10,6 +10,7 @@ module Types
     field :description, String, null: true
     field :title, String, null: true
     field :dates, [QueryTypes::DateType], null: true
+    field :date, QueryTypes::DateType, null: true
     field :list_date, String, null: true
     field :repeat, Boolean, null: true
     field :repeat_duration, QueryTypes::RepeatDurationType, null: true
@@ -33,5 +34,9 @@ module Types
     field :recurring_interval, Integer, null: true
     field :updated_at, String, null: true
     field :created_at, String, null: true
+
+    def dates
+      object.upcoming_dates
+    end
   end
 end

--- a/app/models/data_resources/event_record.rb
+++ b/app/models/data_resources/event_record.rb
@@ -93,7 +93,7 @@ class EventRecord < ApplicationRecord
       .distinct
   }
 
-  scope :upcoming_with_date_select, lambda { |current_user = nil|
+  scope :upcoming_with_date_select, lambda {
     select_clause = <<~SQL
       event_records.*,
       fixed_dates.id AS fixed_date_id,
@@ -106,7 +106,10 @@ class EventRecord < ApplicationRecord
       fixed_dates.use_only_time_description AS fixed_use_only_time_description
     SQL
 
-    select(select_clause)
+    # ignore the first date for recurring events, because it is the original date object with
+    # a time span that should not be listed in the returning event records.
+    where("fixed_dates.id != (SELECT MIN(fd.id) FROM fixed_dates fd WHERE fd.dateable_id = event_records.id)")
+      .select(select_clause)
   }
 
   scope :by_category, lambda { |category_id|

--- a/app/models/data_resources/event_record.rb
+++ b/app/models/data_resources/event_record.rb
@@ -108,7 +108,7 @@ class EventRecord < ApplicationRecord
 
     # ignore the first date for recurring events, because it is the original date object with
     # a time span that should not be listed in the returning event records.
-    where("fixed_dates.id != (SELECT MIN(fd.id) FROM fixed_dates fd WHERE fd.dateable_id = event_records.id)")
+    where("event_records.recurring = false OR fixed_dates.id != (SELECT MIN(fd.id) FROM fixed_dates fd WHERE fd.dateable_id = event_records.id)")
       .select(select_clause)
   }
 

--- a/app/models/data_resources/event_record.rb
+++ b/app/models/data_resources/event_record.rb
@@ -41,6 +41,8 @@ class EventRecord < ApplicationRecord
   # defined by FilterByRole
   # scope :visible, -> { where(visible: true) }
 
+  delegate :upcoming, to: :dates, prefix: true
+
   # timespan_to_search und timespan werden Arrays der Eventzeiträume
   # und deren Schnittemenge > 0 bedeutet eine Überschneidung.
   #
@@ -224,10 +226,6 @@ class EventRecord < ApplicationRecord
     calculated_list_date = event_dates.last.try(:date_start)
     RedisAdapter.set_event_list_date(id, calculated_list_date.try(:to_time).to_i)
     calculated_list_date
-  end
-
-  def upcoming_dates
-    dates.upcoming
   end
 
   def settings

--- a/app/models/data_resources/resource_modules/fixed_date.rb
+++ b/app/models/data_resources/resource_modules/fixed_date.rb
@@ -4,8 +4,11 @@
 class FixedDate < ApplicationRecord
   belongs_to :dateable, polymorphic: true
 
-  scope :upcoming, lambda { |current_user = nil|
-    where("date_start >= ? OR date_end >= ?", Date.today, Date.today)
+  # upcoming fixed dates with ignoring the first one if the resource is an recurring event
+  scope :upcoming, lambda { |ignore_first = false|
+    where_clause = "date_start >= ? OR date_end >= ?"
+    return where(where_clause, Date.today, Date.today).where.not(id: first.id) if ignore_first
+    where(where_clause, Date.today, Date.today)
   }
 end
 

--- a/app/models/data_resources/resource_modules/fixed_date.rb
+++ b/app/models/data_resources/resource_modules/fixed_date.rb
@@ -3,6 +3,10 @@
 # provides dates to other resources (e.g. Events) who need a fixed dates
 class FixedDate < ApplicationRecord
   belongs_to :dateable, polymorphic: true
+
+  scope :upcoming, lambda { |current_user = nil|
+    where("date_start >= ? OR date_end >= ?", Date.today, Date.today)
+  }
 end
 
 # == Schema Information

--- a/app/services/recurring_dates_for_event_service.rb
+++ b/app/services/recurring_dates_for_event_service.rb
@@ -14,6 +14,16 @@ class RecurringDatesForEventService
   end
 
   def create_with_pattern
+    # first, create complete time span
+    FixedDate.create(
+      date_start: @date_start,
+      date_end: @date_end,
+      time_start: @time_start,
+      time_end: @time_end,
+      dateable_type: "EventRecord",
+      dateable_id: @event_id
+    )
+
     case @type
     when 0
       create_daily_events


### PR DESCRIPTION
- each date of an event should be presented as an own event though the api
- this is achieved with adjustment of the sql and adding a new field `date` in GraphQL which holds one date of all dates and all events are returned multiple times depending on their number of dates
- the resolver is updated in a way, that the old logic is still working
  - if the query contains the new `date`, the new scope is used with the specific select which than requests each date
  - if the query does not contain the new `date` the old scope is used and events are returned once like before

SVAK-25

---

the request can take longer now, as more events will be returned. if one event is recurring and has hundreds of dates, hundreds of events will result. this was the wish, as it is the only way to display every date in the calendar and in the list without just relying on the `list_date`.

beside

```
dates {
  dateFrom: dateStart
  dateTo: dateEnd
  timeStart
  timeEnd
}
```

a new

```
date {
  dateFrom: dateStart
  dateTo: dateEnd
  timeStart
  timeEnd
}
```

can be requested.
an event with two dates will now be returned twice, each with one date of the two dates, but still having all dates available for showing details.